### PR TITLE
Accordion Component: Add keyboard focus states (HackBeanpot#71)

### DIFF
--- a/src/components/CustomAccordion.js
+++ b/src/components/CustomAccordion.js
@@ -15,15 +15,23 @@ class CustomAccordion extends React.Component {
       const isCurrentEventKey = currentEventKey === eventKey;
 
       return (
-        <div className={`accordion-header ${largeHeader ? 'accordion-header-large' : ''}`} onClick={toggleIconOnClick}>
+        <button
+          className={`accordion-header ${largeHeader ? 'accordion-header-large' : ''}`}
+          onClick={toggleIconOnClick}
+        >
           <span xs="auto">
-            {isCurrentEventKey ? <Minus className="accordion-header-icon" /> : <Plus className="accordion-header-icon" />}
+            {isCurrentEventKey ? (
+              <Minus className="accordion-header-icon" />
+            ) : (
+              <Plus className="accordion-header-icon" />
+            )}
           </span>
-          { largeHeader ?
-            <h5 className="accordion-header-title">{children}</h5> :
+          {largeHeader ? (
+            <h5 className="accordion-header-title">{children}</h5>
+          ) : (
             <span className="accordion-header-title">{children}</span>
-          }
-        </div>
+          )}
+        </button>
       );
     }
     return (

--- a/src/styling/Accordion.css
+++ b/src/styling/Accordion.css
@@ -5,12 +5,17 @@
 }
 
 .accordion-header {
-  cursor: pointer;
   display: flex;
+  width: 100%;
   font-family: ArchivoBold;
   font-size: 20px;
   background-color: var(--main-cream);
+  border: none;
   padding: 1rem;
+}
+
+.accordion-header:focus {
+  outline-offset: -2px;
 }
 
 .accordion-header .accordion-header-icon {
@@ -19,7 +24,7 @@
 
 .accordion-header-large .accordion-header-icon {
   width: 32px;
-  height: 32px
+  height: 32px;
 }
 
 .accordion-section-container .accordion-header-title {
@@ -69,7 +74,7 @@
   .accordion-header-large .accordion-header-title {
     line-height: 20px;
   }
-  
+
   .accordion-header .accordion-header-icon {
     width: 16px;
   }


### PR DESCRIPTION
** Proposed changes **
* Use `<button>` for Accordion header to achieve focus states and keyboard accessibility

- [x] I tested my changes on mobile size screens
- [x] I tested my changes on tablet size screens

** Screenshots and gifs **
![Screen Shot 2020-09-01 at 11 57 53 PM](https://user-images.githubusercontent.com/2482343/91930525-0ecd7800-ecaf-11ea-8819-c63092576575.png)

This solves half of #71; need to think on what the correct way to add aria attributes with the react-bootstrap library.

Thanks!