### PR TITLE
image styling fixes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -176,15 +176,13 @@ hr {
   left: 50%;
 }
 
-@media only screen and (max-width: 992px) {
-  .flow-images {
-    max-width: 90%;
-    height: auto;
-  }
+.flow-images {
+  max-width: 60%;
+  height: auto;
 }
 
 .spinner-row {
-  margin-top: 3rem
+  margin-top: 3rem;
 }
 
 .spinner {
@@ -196,7 +194,7 @@ hr {
   hr {
     margin: 2rem 0;
   }
-  
+
   h1 {
     font-size: 40px;
   }

--- a/src/pages/ProjectsPage.js
+++ b/src/pages/ProjectsPage.js
@@ -3,9 +3,9 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Row, Col, Container, Spinner } from 'react-bootstrap';
 import NewsletterForm from '../components/NewsletterForm';
 import { ProjectsPageTemp } from './ProjectsPageTemp';
-import ProjectCard from '../components/ProjectCard'
+import ProjectCard from '../components/ProjectCard';
 import ProjectSelectFlow from '../assets/flow_diagrams/project_selection_flow';
-import { fetchOpenProjects } from '../state/utils'
+import { fetchOpenProjects } from '../state/utils';
 import { createProjects } from '../state/projects';
 
 import '../styling/ProjectsPage.css';
@@ -21,23 +21,25 @@ const ProjectsPage = () => {
       await dispatch(createProjects(airtableRecords));
       setProjects(airtableRecords);
       setHasLoaded(true);
-    }
+    };
 
     if (savedProjects.length === 0 && !hasLoaded) {
-      fetchOpenProjects(doOnSuccess)
+      fetchOpenProjects(doOnSuccess);
     } else {
       setHasLoaded(true);
     }
   }, [dispatch, savedProjects, hasLoaded]);
 
   if (hasLoaded && projects.length === 0) {
-    return <ProjectsPageTemp />
+    return <ProjectsPageTemp />;
   }
 
   return (
     <Container className="projects-page">
       <h1>Open Projects</h1>
-      <ProjectSelectFlow className="flow-images" />
+      <Row className="justify-content-center d-flex flex-wrap align-items-center">
+        <ProjectSelectFlow className="flow-images" />
+      </Row>
       {hasLoaded ? (
         <Row className="d-flex justify-content-left">
           {projects.map((project) => (

--- a/src/styling/HomePage.css
+++ b/src/styling/HomePage.css
@@ -57,6 +57,11 @@
   height: auto;
 }
 
+.home-page .flow-images {
+  max-width: 70%;
+  height: auto;
+}
+
 @media only screen and (max-width: 1200px) {
   .logo {
     max-width: 220px;
@@ -87,7 +92,7 @@
   .home-track-body {
     margin-top: 35px;
   }
-  
+
   .home-comm-partners-icon {
     max-width: 250px;
   }
@@ -126,6 +131,10 @@
 @media only screen and (max-width: 468px) {
   .home-comm-partners-icon {
     max-width: 120px;
+  }
+
+  .home-page .flow-images {
+    max-width: 300px;
   }
 }
 

--- a/src/styling/ProjectsPage.css
+++ b/src/styling/ProjectsPage.css
@@ -6,12 +6,6 @@
   padding: 0 48px;
 }
 
-.projects-page .flow-images {
-  margin: 3em auto;
-  display: block;
-  padding-right: 1rem;
-}
-
 .preview-card {
   border-radius: 16px;
   margin: 16px 0px;
@@ -152,7 +146,7 @@
 }
 
 .project-loading-spinner {
-  margin-top: 3rem
+  margin-top: 3rem;
 }
 
 .project-description-note {

--- a/src/styling/RequestPage.css
+++ b/src/styling/RequestPage.css
@@ -2,10 +2,6 @@
   margin: 3rem auto;
 }
 
-#request-page h1 {
-  margin-bottom: 1rem;
-}
-
 .request-form-show {
   opacity: 1;
   height: 100%;

--- a/src/styling/RequestPage.css
+++ b/src/styling/RequestPage.css
@@ -2,10 +2,6 @@
   margin: 3rem auto;
 }
 
-#request-page .flow-images {
-  margin: 3em auto;
-}
-
 #request-page h1 {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
**Proposed changes**
* Adjust margin and size of flow diagram images to be smaller on all screen sizes (except for on home page)

- [x] I tested my changes on mobile size screens
- [x] I tested my changes on tablet size screens

**Screenshots and gifs**
<img width="400" alt="Screen Shot 2020-09-05 at 9 29 52 PM" src="https://user-images.githubusercontent.com/43453743/92316457-54958380-efc2-11ea-9bb5-dc4596e35690.png">
<img width="219" alt="Screen Shot 2020-09-05 at 9 29 26 PM" src="https://user-images.githubusercontent.com/43453743/92316459-58290a80-efc2-11ea-99b0-2505712900b1.png">
<img width="400" alt="Screen Shot 2020-09-05 at 9 31 09 PM" src="https://user-images.githubusercontent.com/43453743/92316461-5f501880-efc2-11ea-8997-e17e3c9f82a1.png">
<img width="219" alt="Screen Shot 2020-09-05 at 9 29 33 PM" src="https://user-images.githubusercontent.com/43453743/92316465-742cac00-efc2-11ea-95a5-7e8094ec8205.png">

